### PR TITLE
Property filter in default object handler

### DIFF
--- a/CsharpExpressionDumper.Tests/CsharpExpressionDumperTests.cs
+++ b/CsharpExpressionDumper.Tests/CsharpExpressionDumperTests.cs
@@ -1,7 +1,9 @@
 using CsharpExpressionDumper.Abstractions;
 using CsharpExpressionDumper.ConstructorResolvers;
 using CsharpExpressionDumper.Extensions;
+using CsharpExpressionDumper.ObjectHandlerPropertyFilters;
 using FluentAssertions;
+using Moq;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -930,6 +932,20 @@ input.Property2 = 3;
         }
 
         [Fact]
+        public void Can_Filter_Empty_Property_Values_On_Dump()
+        {
+            // Arrange
+            var input = new MyFlatClass();
+            var filter = new SkipDefaultValues();
+
+            // Act
+            var actual = Dump(input, new[] { filter });
+
+            // Asset
+            actual.Should().Be(@"new CsharpExpressionDumper.Tests.CsharpExpressionDumperTests.MyFlatClass()");
+        }
+
+        [Fact]
         public void Dump_Throws_InvalidOperationExcepion_When_No_ObjectHandler_Supports_The_Object_Instance()
         {
             // Arrange
@@ -939,7 +955,8 @@ input.Property2 = 3;
                 Enumerable.Empty<ICustomTypeHandler>(),
                 Default.TypeNameFormatters,
                 Default.ConstructorResolvers,
-                Default.ReadOnlyPropertyResolvers
+                Default.ReadOnlyPropertyResolvers,
+                Default.ObjectHandlerPropertyFilters
             );
 
             // Act & Assert
@@ -956,7 +973,8 @@ input.Property2 = 3;
                 customTypeHandlers.Concat(Default.CustomTypeHandlers),
                 Default.TypeNameFormatters,
                 Default.ConstructorResolvers,
-                Default.ReadOnlyPropertyResolvers
+                Default.ReadOnlyPropertyResolvers,
+                Default.ObjectHandlerPropertyFilters
             );
             return sut.Dump(input, typeof(T));
         }
@@ -969,7 +987,22 @@ input.Property2 = 3;
                 Default.CustomTypeHandlers,
                 Default.TypeNameFormatters,
                 constructorResolvers,
-                Default.ReadOnlyPropertyResolvers
+                Default.ReadOnlyPropertyResolvers,
+                Default.ObjectHandlerPropertyFilters
+            );
+            return sut.Dump(input, typeof(T));
+        }
+
+        private string Dump<T>(T input, IObjectHandlerPropertyFilter[] objectHandlerPropertyFilters)
+        {
+            var sut = new CsharpExpressionDumper
+            (
+                Default.ObjectHandlers,
+                Default.CustomTypeHandlers,
+                Default.TypeNameFormatters,
+                Default.ConstructorResolvers,
+                Default.ReadOnlyPropertyResolvers,
+                objectHandlerPropertyFilters
             );
             return sut.Dump(input, typeof(T));
         }

--- a/CsharpExpressionDumper/Abstractions/ICsharpExpressionDumperCallback.cs
+++ b/CsharpExpressionDumper/Abstractions/ICsharpExpressionDumperCallback.cs
@@ -16,6 +16,7 @@ namespace CsharpExpressionDumper.Abstractions
         void AppendTypeName(Type type);
         ICsharpExpressionDumperCallback CreateNestedCallback(string prefix, string suffix);
         bool IsPropertyCustom(CustomTypeHandlerCommand propertyCommand, ICsharpExpressionDumperCallback propertyCallback);
+        bool IsPropertyValid(ObjectHandlerCommand command, PropertyInfo propertyInfo);
         ConstructorInfo ResolveConstructor(Type type);
         PropertyInfo ResolveReadOnlyProperty(PropertyInfo[] properties, ConstructorInfo ctor, ParameterInfo argument);
     }

--- a/CsharpExpressionDumper/Abstractions/IObjectHandlerPropertyFilter.cs
+++ b/CsharpExpressionDumper/Abstractions/IObjectHandlerPropertyFilter.cs
@@ -1,0 +1,9 @@
+﻿using System.Reflection;
+
+namespace CsharpExpressionDumper.Abstractions
+{
+    public interface IObjectHandlerPropertyFilter
+    {
+        bool IsValid(ObjectHandlerCommand command, PropertyInfo propertyInfo);
+    }
+}

--- a/CsharpExpressionDumper/CsharpExpressionDumper.cs
+++ b/CsharpExpressionDumper/CsharpExpressionDumper.cs
@@ -15,18 +15,21 @@ namespace CsharpExpressionDumper
         private readonly IReadOnlyCollection<ITypeNameFormatter> _typeNameFormatters;
         private readonly IReadOnlyCollection<IConstructorResolver> _constructorResolvers;
         private readonly IReadOnlyCollection<IReadOnlyPropertyResolver> _readOnlyPropertyResolvers;
+        private readonly IEnumerable<IObjectHandlerPropertyFilter> _objectHandlerPropertyFilters;
 
         public CsharpExpressionDumper(IEnumerable<IObjectHandler> objectHandlers,
                                       IEnumerable<ICustomTypeHandler> customTypeHandlers,
                                       IEnumerable<ITypeNameFormatter> typeNameFormatters,
                                       IEnumerable<IConstructorResolver> constructorResolvers,
-                                      IEnumerable<IReadOnlyPropertyResolver> readOnlyPropertyResolvers)
+                                      IEnumerable<IReadOnlyPropertyResolver> readOnlyPropertyResolvers,
+                                      IEnumerable<IObjectHandlerPropertyFilter> objectHandlerPropertyFilters)
         {
             _objectHandlers = new List<IObjectHandler>(objectHandlers ?? Enumerable.Empty<IObjectHandler>());
             _customTypeHandlers = new List<ICustomTypeHandler>(customTypeHandlers ?? Enumerable.Empty<ICustomTypeHandler>());
             _typeNameFormatters = new List<ITypeNameFormatter>(typeNameFormatters ?? Enumerable.Empty<ITypeNameFormatter>());
             _constructorResolvers = new List<IConstructorResolver>(constructorResolvers ?? Enumerable.Empty<IConstructorResolver>());
             _readOnlyPropertyResolvers = new List<IReadOnlyPropertyResolver>(readOnlyPropertyResolvers ?? Enumerable.Empty<IReadOnlyPropertyResolver>());
+            _objectHandlerPropertyFilters = new List<IObjectHandlerPropertyFilter>(objectHandlerPropertyFilters ?? Enumerable.Empty<IObjectHandlerPropertyFilter>());
         }
 
         public string Dump(object instance, Type type = null)
@@ -48,7 +51,8 @@ namespace CsharpExpressionDumper
                 _customTypeHandlers,
                 _typeNameFormatters,
                 _constructorResolvers,
-                _readOnlyPropertyResolvers
+                _readOnlyPropertyResolvers,
+                _objectHandlerPropertyFilters
             );
             var instanceCommand = new CustomTypeHandlerCommand(instance, instanceType, level);
             var instanceIsCustom = _customTypeHandlers.ProcessUntilSuccess(x => x.Process(instanceCommand, instanceCallback));

--- a/CsharpExpressionDumper/Default.cs
+++ b/CsharpExpressionDumper/Default.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using CsharpExpressionDumper.Abstractions;
 using CsharpExpressionDumper.ConstructorResolvers;
 using CsharpExpressionDumper.CustomTypeHandlers;
@@ -55,10 +56,14 @@ namespace CsharpExpressionDumper
                     new DefaultTypeNameFormatter()
                 });
 
+        public static IEnumerable<IObjectHandlerPropertyFilter> ObjectHandlerPropertyFilters
+            => _objectHandlerPropertyFilters ?? (_objectHandlerPropertyFilters = Array.Empty<IObjectHandlerPropertyFilter>());
+
         private static IEnumerable<IObjectHandler> _objectHandlers;
         private static IEnumerable<ICustomTypeHandler> _customTypeHandlers;
         private static IEnumerable<IConstructorResolver> _constructorResolvers;
         private static IEnumerable<IReadOnlyPropertyResolver> _readOnlyPropertyResolvers;
         private static IEnumerable<ITypeNameFormatter> _typeNameFormatters;
+        private static IEnumerable<IObjectHandlerPropertyFilter> _objectHandlerPropertyFilters;
     }
 }

--- a/CsharpExpressionDumper/ObjectHandlerPropertyFilters/SkipDefaultValues.cs
+++ b/CsharpExpressionDumper/ObjectHandlerPropertyFilters/SkipDefaultValues.cs
@@ -1,0 +1,27 @@
+﻿using CsharpExpressionDumper.Abstractions;
+using System;
+using System.Reflection;
+
+namespace CsharpExpressionDumper.ObjectHandlerPropertyFilters
+{
+    public class SkipDefaultValues : IObjectHandlerPropertyFilter
+    {
+        public bool IsValid(ObjectHandlerCommand command, PropertyInfo propertyInfo)
+        {
+            var defaultValue = propertyInfo.PropertyType.IsValueType && Nullable.GetUnderlyingType(propertyInfo.PropertyType) == null
+                ? Activator.CreateInstance(propertyInfo.PropertyType)
+                : null;
+            
+            var actualValue = propertyInfo.GetValue(command.Instance);
+
+            if (defaultValue == null && actualValue == null)
+            {
+                return false;
+            }
+
+            return defaultValue == null
+                || actualValue == null
+                || !actualValue.Equals(defaultValue);
+        }
+    }
+}

--- a/CsharpExpressionDumper/ObjectHandlers/DefaultObjectHandler.cs
+++ b/CsharpExpressionDumper/ObjectHandlers/DefaultObjectHandler.cs
@@ -75,6 +75,7 @@ namespace CsharpExpressionDumper.ObjectHandlers
                 property =>
                     (command.IsAnonymousType || !property.IsReadOnly())
                     && !processedProperties.Contains(property.Name)
+                    && callback.IsPropertyValid(command, property)
             ).ToArray();
 
             if (!first)


### PR DESCRIPTION
Added property filter in default object, so you can skip properties. For example, you can skip default values to shorten the expression.