### PR TITLE
Removed unnecessary argument null check

### DIFF
--- a/src/CsharpExpressionDumper.Core.Tests/CsharpExpressionDumperTests.cs
+++ b/src/CsharpExpressionDumper.Core.Tests/CsharpExpressionDumperTests.cs
@@ -9,28 +9,12 @@ using CsharpExpressionDumper.Core.CsharpExpressionDumperCallbacks;
 using CsharpExpressionDumper.Core.ObjectHandlerPropertyFilters;
 using CsharpExpressionDumper.Core.Tests.TestData;
 using FluentAssertions;
-using Moq;
 using Xunit;
 
 namespace CsharpExpressionDumper.Core.Tests
 {
     public partial class CsharpExpressionDumperTests
     {
-        [Fact]
-        public void Ctor_Throws_ArgumentNullException_On_Null_Arguments()
-        {
-            //TODO: Add support in TestHelpers (CrossCutting.Common) so we can perform this test with the generic TestHelpers class.
-            this.Invoking(_ => new CsharpExpressionDumper(Enumerable.Empty<IObjectHandler>(), Enumerable.Empty<ICustomTypeHandler>(), null))
-                .Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("instanceCallback");
-
-            this.Invoking(_ => new CsharpExpressionDumper(null, Enumerable.Empty<ICustomTypeHandler>(), new Mock<ICsharpExpressionDumperCallback>().Object))
-                .Should().NotThrow<ArgumentNullException>();
-
-            this.Invoking(_ => new CsharpExpressionDumper(Enumerable.Empty<IObjectHandler>(), null, new Mock<ICsharpExpressionDumperCallback>().Object))
-                .Should().NotThrow<ArgumentNullException>();
-        }
-
         [Fact]
         public void Can_Dump_String_To_Csharp()
         {

--- a/src/CsharpExpressionDumper.Core/CsharpExpressionDumper.cs
+++ b/src/CsharpExpressionDumper.Core/CsharpExpressionDumper.cs
@@ -20,7 +20,7 @@ namespace CsharpExpressionDumper.Core
         {
             _objectHandlers = new List<IObjectHandler>(objectHandlers ?? Enumerable.Empty<IObjectHandler>());
             _customTypeHandlers = new List<ICustomTypeHandler>(customTypeHandlers ?? Enumerable.Empty<ICustomTypeHandler>());
-            _instanceCallback = instanceCallback ?? throw new ArgumentNullException(nameof(instanceCallback));
+            _instanceCallback = instanceCallback;
         }
 
         public string Dump(object instance, Type? type = null)


### PR DESCRIPTION
you'll get a warning when you try to do this, thanks to nullable reference types